### PR TITLE
Delete 3 CSS declaration in the code selector rule.

### DIFF
--- a/dark-soda.css
+++ b/dark-soda.css
@@ -50,9 +50,6 @@
 }
 code {
     padding: 2px 4px;
-    color: #d14;
-    background-color: rgb(158, 158, 158);
-    border: 1px solid rgb(122, 122, 122);
     white-space: nowrap;
 }
 


### PR DESCRIPTION
When using the QuickDocsJS plugin, code text is highlighted in a light color and red rendering it hard to read:

![screenshot 2015-03-16 14 19 54](https://cloud.githubusercontent.com/assets/665802/6676799/cdc76e08-cbe7-11e4-9009-2bcce8557953.png)

I changed:

code {
    padding: 2px 4px;
    color: #d14;
    background-color: rgb(158, 158, 158);
    border: 1px solid rgb(122, 122, 122);
    white-space: nowrap;
}

to: 

code {
   padding: 2px 4px;
   white-space: nowrap;
}

And now it looks like:

![screenshot 2015-03-27 10 36 51](https://cloud.githubusercontent.com/assets/665802/6873394/35c969d8-d46d-11e4-8bb7-fedaca293def.png)
